### PR TITLE
update examples to remove deprecated methods

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -3,9 +3,6 @@ const { exec, execSync } = require('child_process');
 const commandline={
     run:runCommand,
     runSync:runSync,
-    //will be deprecated soon as run is now the same.
-    get:runCommand,
-    
 };
 
 function runCommand(command,callback){

--- a/example/basic-unix.js
+++ b/example/basic-unix.js
@@ -1,6 +1,6 @@
 var cmd=require('../cmd.js');
 
-const syncDir = cmd.getSync("pwd");
+const syncDir = cmd.runSync("pwd");
 
 console.log(`
 

--- a/example/getPID.js
+++ b/example/getPID.js
@@ -1,4 +1,4 @@
 var cmd=require('../cmd.js');
 
-var processRef=cmd.get('node');
+var processRef=cmd.run('node');
 console.log(processRef.pid);

--- a/example/nodePythonTerminal.js
+++ b/example/nodePythonTerminal.js
@@ -1,6 +1,6 @@
 const cmd=require('../cmd.js');
 
-const processRef=cmd.get('python -i');
+const processRef=cmd.run('python -i');
 let data_line = '';
 
 //listen to the python terminal output


### PR DESCRIPTION
Simply swapped out the to-be-deprecated "get" methods from 3 of the code examples and replaced them with "run."

From a scan of the code it looks like getSync was already deprecated.

