### PR TITLE
update readme to fix typo (issue #53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,15 @@ ls`,
 
 //Windows multiline commands are not guaranteed to work try condensing to a single line.
     
-    const syncData=cmd.runSync('cd ./example & dir');
+    const syncDir=cmd.runSync('cd ./example & dir');
 
     console.log(`
     
-        Sync Err ${syncData.err}
+        Sync Err ${syncDir.err}
         
         Sync stderr:  ${syncDir.stderr}
 
-        Sync Data ${syncData.data}
+        Sync Data ${syncDir.data}
     
     `);
 


### PR DESCRIPTION
Resolve issue #53 by changing `syncData` to `syncDir`. 

This matches the example files while addressing the typo pointed out in the issue. 

Happy to revert the change and use `syncData` everywhere if preferred for a reason I don't see, but this seems like the best option for consistency and clarity. 